### PR TITLE
Pez/bencode

### DIFF
--- a/perl/bencode/lib/LingyBencode.pm
+++ b/perl/bencode/lib/LingyBencode.pm
@@ -2,6 +2,7 @@ use strict; use warnings;
 package LingyBencode;
 
 use Lingy::Common;
+use Data::Dumper;
 
 use Bencode;
 
@@ -11,5 +12,12 @@ sub bencode {
     my $bencoded = Bencode::bencode($hash);
     STRING->new($bencoded);
 }
+
+sub bdecode {
+    my ($string) = @_;
+    my $bdecoded = Bencode::bdecode($string);
+    HASHMAP->new($bdecoded);
+}
+
 
 1;

--- a/perl/lib/Lingy/HashMap.pm
+++ b/perl/lib/Lingy/HashMap.pm
@@ -6,15 +6,26 @@ use base 'immutable::map', 'Lingy::Class';
 use Lingy::Common;
 
 sub new {
-    my ($class, $list) = @_;
+    my ($class, $data) = @_;
     my (@keys, %vals);
-    for (my $i = @$list - 2; $i >= 0; $i -= 2) {
-        my $key = $class->_get_key($list->[$i]);
-        if (not exists $vals{$key}) {
-            unshift @keys, $key;
-            $vals{$key} = $list->[$i + 1];
+
+    if (ref($data) eq 'HASH') {
+        @keys = keys %$data;
+        %vals = %$data;
+    }
+    elsif (ref($data) eq 'ARRAY') {
+        for (my $i = @$data - 2; $i >= 0; $i -= 2) {
+            my $key = $class->_get_key($data->[$i]);
+            if (not exists $vals{$key}) {
+                unshift @keys, $key;
+                $vals{$key} = $data->[$i + 1];
+            }
         }
     }
+    else {
+        die "Argument must be a reference to a hash or an array.\n";
+    }
+
     my @data = map { ($_, $vals{$_}) } @keys;
     my $self = $class->SUPER::new(@data);
     return $self;


### PR DESCRIPTION
Alright so this is probably bonkers and crap, but I got the `Bencode/bdecode` working if I allow the creation of a `Lingy::Hashmap` from a hash. 

Unlike with encoding, I can't (rather, don't know how to) stay fully in Lingy, for the decoding, because I don't know how to dereference the data structure returned from `Bencode/bdecode` as a hash in Lingy land. ChatGPT showed me how to do it in Perl land so with the glue example module/package/lib (what is it called?) it works. This:

```clojure
(ns lingy.nrepl
  (:import Bencode LingyBencode Data.Dumper))

(def data {:age 25 :eyes "blue"})

(def bencoded (-> data
                  .unbox
                  Bencode/bencode
                  String.))

(println bencoded)

#_(def decoded (Bencode/bdecode bencoded))
(def decoded (LingyBencode/bdecode bencoded))
(use 'lingy.devel)
(XXX decoded)
#_(println "decoded: " (Data.Dumper decoded))
(println "age: " (:age decoded))
(println "decoded-map: " decoded)
```

Gives:

```
❯ lingy -D src/lingy/nrepl.ly
d4::agei25e5::eyes4:bluee
--- !perl/hash:Lingy::HashMap
:age: '25'
:eyes: blue
...
age:  25
decoded-map:  {:age 25, :eyes blue}
```
